### PR TITLE
remove duplicate Flatpickr controller registration

### DIFF
--- a/app/javascript/stimulus_js/index.js
+++ b/app/javascript/stimulus_js/index.js
@@ -1,10 +1,6 @@
 import { Application } from "stimulus";
 import { definitionsFromContext } from "stimulus/webpack-helpers";
-import Flatpickr from "stimulus-flatpickr";
 
 const application = Application.start();
 const context = require.context("./controllers", true, /\.js$/);
 application.load(definitionsFromContext(context));
-
-// Manually register Flatpickr as a stimulus controller
-application.register("flatpickr", Flatpickr);


### PR DESCRIPTION
hello there

looking at the dependency of my little package stimulus-flatpickr I have discovered your project. Thanks for using it!
if you don't mind I would like to propose a small improvement to the way you are using the package.
Currently, you have a mix of the basic usage and advanced usage describe in the documentation. As a result, I think you are currently registering twice the stimulus controller.
One with the  `const context = require.context("./controllers", true, /\.js$/);` which will load the flatpickr_controller.js you have defined and the other one with the manual controller registering. 

You should do one or the other. Since you are using a custom theme I think the advanced usage is more appropriate and this PR remove the manual registration.

I wasn't able to test the app as `rails db:migrate` failed for me but I am pretty sure it will work as expected


